### PR TITLE
new: Add `#[system]` attribute for functions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        name: Setup toolchain
+        with:
+          toolchain: 1.68.2
+          profile: minimal
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        name: Check formatting
+        with:
+          command: fmt
+          args: --all --check
+  lint:
+    name: Lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        name: Setup toolchain
+        with:
+          toolchain: 1.68.2
+          profile: minimal
+          components: clippy
+      - uses: actions-rs/cargo@v1
+        name: Run linter
+        with:
+          command: clippy
+          args: --workspace --all-targets
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        name: Setup toolchain
+        with:
+          toolchain: 1.68.2
+          profile: minimal
+      - uses: actions-rs/cargo@v1
+        name: Run tests
+        with:
+          command: test
+          args: --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,19 +4,19 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -84,7 +84,7 @@ checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -95,9 +95,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -120,15 +120,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -137,38 +137,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.12",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -391,7 +391,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -405,6 +405,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -448,7 +459,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "relative-path"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +377,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
+ "relative-path",
  "rustc-hash",
  "starship_macros",
  "tokio",

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -8,5 +8,6 @@ starship_macros = { path = "../macros" }
 anyhow = "1.0.69"
 async-trait = "0.1.61"
 futures = "0.3.25"
+relative-path = "1.8.0"
 rustc-hash = "1.1.0"
 tokio = { version = "1.25.0", features = ["full", "tracing"] }

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 starship_macros = { path = "../macros" }
-anyhow = "1.0.69"
-async-trait = "0.1.61"
-futures = "0.3.25"
+anyhow = "1.0.70"
+async-trait = "0.1.68"
+futures = "0.3.28"
 relative-path = "1.8.0"
 rustc-hash = "1.1.0"
-tokio = { version = "1.25.0", features = ["full", "tracing"] }
+tokio = { version = "1.26.0", features = ["full", "tracing"] }

--- a/crates/framework/src/context.rs
+++ b/crates/framework/src/context.rs
@@ -32,36 +32,36 @@ impl ContextManager {
         panic!("No emitter found for type {:?}", type_name::<Emitter<E>>())
     }
 
-    pub fn resource<C: Any + Send + Sync + Resource>(&self) -> &C {
-        if let Some(value) = self.resources.get(&TypeId::of::<C>()) {
-            return value.downcast_ref::<C>().unwrap();
+    pub fn resource<R: Any + Send + Sync + Resource>(&self) -> &R {
+        if let Some(value) = self.resources.get(&TypeId::of::<R>()) {
+            return value.downcast_ref::<R>().unwrap();
         }
 
-        panic!("No resource found for type {:?}", type_name::<C>())
+        panic!("No resource found for type {:?}", type_name::<R>())
     }
 
-    pub fn resource_mut<C: Any + Send + Sync + Resource>(&mut self) -> &mut C {
-        if let Some(value) = self.resources.get_mut(&TypeId::of::<C>()) {
-            return value.downcast_mut::<C>().unwrap();
+    pub fn resource_mut<R: Any + Send + Sync + Resource>(&mut self) -> &mut R {
+        if let Some(value) = self.resources.get_mut(&TypeId::of::<R>()) {
+            return value.downcast_mut::<R>().unwrap();
         }
 
-        panic!("No resource found for type {:?}", type_name::<C>())
+        panic!("No resource found for type {:?}", type_name::<R>())
     }
 
-    pub fn state<C: Any + Send + Sync + State>(&self) -> &C {
-        if let Some(value) = self.state.get(&TypeId::of::<C>()) {
-            return value.downcast_ref::<C>().unwrap();
+    pub fn state<S: Any + Send + Sync + State>(&self) -> &S {
+        if let Some(value) = self.state.get(&TypeId::of::<S>()) {
+            return value.downcast_ref::<S>().unwrap();
         }
 
-        panic!("No state found for type {:?}", type_name::<C>())
+        panic!("No state found for type {:?}", type_name::<S>())
     }
 
-    pub fn state_mut<C: Any + Send + Sync + State>(&mut self) -> &mut C {
-        if let Some(value) = self.state.get_mut(&TypeId::of::<C>()) {
-            return value.downcast_mut::<C>().unwrap();
+    pub fn state_mut<S: Any + Send + Sync + State>(&mut self) -> &mut S {
+        if let Some(value) = self.state.get_mut(&TypeId::of::<S>()) {
+            return value.downcast_mut::<S>().unwrap();
         }
 
-        panic!("No state found for type {:?}", type_name::<C>())
+        panic!("No state found for type {:?}", type_name::<S>())
     }
 
     pub fn add_emitter<E: Event + 'static>(&mut self, instance: Emitter<E>) -> &mut Self {

--- a/crates/framework/src/lib.rs
+++ b/crates/framework/src/lib.rs
@@ -14,3 +14,4 @@ pub use state::*;
 pub use system::*;
 
 pub use anyhow::Result;
+pub use relative_path::{RelativePath, RelativePathBuf};

--- a/crates/framework/tests/app_test.rs
+++ b/crates/framework/tests/app_test.rs
@@ -1,4 +1,5 @@
 use starship::{App, Context, Result, State};
+use starship_macros::*;
 use std::time::Duration;
 use tokio::task;
 use tokio::time::sleep;
@@ -6,19 +7,14 @@ use tokio::time::sleep;
 #[derive(State)]
 struct RunOrder(pub Vec<String>);
 
-async fn setup_state(ctx: Context) -> Result<()> {
-    ctx.write().await.add_state(RunOrder(vec![]));
-
-    Ok(())
+#[system]
+async fn setup_state(ctx: ContextMut) {
+    ctx.add_state(RunOrder(vec![]));
 }
 
-async fn system(ctx: Context) -> Result<()> {
-    ctx.write()
-        .await
-        .state_mut::<RunOrder>()
-        .push("async-function".into());
-
-    Ok(())
+#[system]
+async fn system(order: StateMut<RunOrder>) {
+    order.push("async-function".into());
 }
 
 async fn system_with_thread(ctx: Context) -> Result<()> {

--- a/crates/framework/tests/app_test.rs
+++ b/crates/framework/tests/app_test.rs
@@ -5,7 +5,7 @@ use tokio::task;
 use tokio::time::sleep;
 
 #[derive(State)]
-struct RunOrder(pub Vec<String>);
+struct RunOrder(Vec<String>);
 
 #[system]
 async fn setup_state(ctx: ContextMut) {

--- a/crates/framework/tests/context_macros_test.rs
+++ b/crates/framework/tests/context_macros_test.rs
@@ -1,0 +1,50 @@
+#![allow(dead_code, unused_must_use)]
+
+use starship::{RelativePathBuf, Resource, State};
+use std::path::PathBuf;
+
+// STATE
+
+#[derive(Debug, State)]
+struct State1;
+
+#[derive(Debug, State)]
+struct State2(usize);
+
+#[derive(Debug, State)]
+struct State3 {
+    count: usize,
+}
+
+#[derive(Debug, State)]
+enum State4 {
+    One,
+    Two,
+    Three,
+}
+
+#[derive(Debug, State)]
+struct StatePath(PathBuf);
+
+#[derive(Debug, State)]
+struct StateRelPath(RelativePathBuf);
+
+// RESOURCE
+
+#[derive(Debug, Resource)]
+struct Resource1;
+
+#[derive(Debug, Resource)]
+struct Resource2(usize);
+
+#[derive(Debug, Resource)]
+struct Resource3 {
+    count: usize,
+}
+
+#[derive(Debug, Resource)]
+enum Resource4 {
+    One,
+    Two,
+    Three,
+}

--- a/crates/framework/tests/system_macros_test.rs
+++ b/crates/framework/tests/system_macros_test.rs
@@ -65,6 +65,18 @@ async fn read_resource_same_arg(arg1: ResourceRef<Resource1>, arg2: ResourceRef<
     dbg!(arg2);
 }
 
+// WRITE
+
+#[system]
+async fn write_context(ctx: ContextMut) {
+    ctx.add_state(State1(123));
+}
+
+#[system]
+async fn write_context_renamed(other: ContextMut) {
+    dbg!(other);
+}
+
 // #[system]
 // async fn write_arg(arg: StateMut<State1>) {
 //     **arg = 2;
@@ -123,10 +135,14 @@ fn non_async(ctx: ContextRef) {
 //     dbg!(other);
 // }
 
+// #[system]
+// async fn fail_mut_context_with_other_args(other: ContextMut, arg: StateRef<State1>) {
+//     other.add_state(State1(123));
+// }
+
 #[tokio::test]
 async fn test_app() {
     let mut app = App::default();
-    app.add_initializer(read_context);
     app.add_initializer(read_context);
     app.add_initializer(read_context_renamed);
     app.add_initializer(read_state_arg);
@@ -135,6 +151,8 @@ async fn test_app() {
     app.add_initializer(read_resource_arg);
     app.add_initializer(read_resource_arg_multi);
     app.add_initializer(read_resource_same_arg);
+    app.add_initializer(write_context);
+    app.add_initializer(write_context_renamed);
     app.add_initializer(non_async);
     app.add_initializer(no_args);
 }

--- a/crates/framework/tests/system_macros_test.rs
+++ b/crates/framework/tests/system_macros_test.rs
@@ -1,0 +1,140 @@
+#![allow(dead_code, unused_must_use)]
+
+use starship::{App, Resource, State};
+use starship_macros::*;
+
+#[derive(Debug, State)]
+struct State1(usize);
+
+#[derive(Debug, State)]
+struct State2(usize);
+
+#[derive(Debug, Resource)]
+struct Resource1 {
+    pub field: usize,
+}
+
+#[derive(Debug, Resource)]
+struct Resource2 {
+    pub field: usize,
+}
+
+// READ
+
+#[system]
+async fn read_context(ctx: ContextRef) {
+    dbg!(ctx);
+}
+
+#[system]
+async fn read_context_renamed(other: ContextRef) {
+    dbg!(other);
+}
+
+#[system]
+async fn read_state_arg(arg: StateRef<State1>) {
+    dbg!(arg);
+}
+
+#[system]
+async fn read_state_arg_multi(arg1: StateRef<State1>, arg2: StateRef<State2>) {
+    dbg!(arg1);
+    dbg!(arg2);
+}
+
+#[system]
+async fn read_state_same_arg(arg1: StateRef<State1>, arg2: StateRef<State1>) {
+    dbg!(arg1);
+    dbg!(arg2);
+}
+
+#[system]
+async fn read_resource_arg(arg: ResourceRef<Resource1>) {
+    dbg!(arg);
+}
+
+#[system]
+async fn read_resource_arg_multi(arg1: ResourceRef<Resource1>, arg2: ResourceRef<Resource2>) {
+    dbg!(arg1);
+    dbg!(arg2);
+}
+
+#[system]
+async fn read_resource_same_arg(arg1: ResourceRef<Resource1>, arg2: ResourceRef<Resource1>) {
+    dbg!(arg1);
+    dbg!(arg2);
+}
+
+// #[system]
+// async fn write_arg(arg: StateMut<State1>) {
+//     **arg = 2;
+//     dbg!(arg);
+// }
+
+// #[system]
+// async fn read_write_arg(arg1: StateRef<State1>, arg2: StateMut<State2>) {
+//     dbg!(arg1);
+//     **arg2 = 2;
+//     dbg!(arg2);
+// }
+
+// MISC
+
+#[system]
+fn no_args() {
+    dbg!("none");
+}
+
+#[system]
+fn non_async(ctx: ContextRef) {
+    dbg!(ctx);
+}
+
+// INVALID
+
+// #[system]
+// async fn fail_invalid_return() {
+//     return Ok(123);
+// }
+
+// TODO?
+// #[system]
+// async fn fail_invalid_return_type() -> Result<usize> {
+//     dbg!("fail");
+// }
+
+// #[system]
+// async fn fail_self(self) {
+//     dbg!(self);
+// }
+
+// #[system]
+// async fn fail_unknown_type(other: ComponentRef) {
+//     dbg!(other);
+// }
+
+// #[system]
+// async fn fail_unknown_wrapper_type(other: OtherRef<State1>) {
+//     dbg!(other);
+// }
+
+// #[system]
+// async fn fail_context_with_other_args(other: ContextRef, arg: StateRef<State1>) {
+//     dbg!(other);
+// }
+
+#[tokio::test]
+async fn test_app() {
+    let mut app = App::default();
+    app.add_initializer(read_context);
+    app.add_initializer(read_context);
+    app.add_initializer(read_context_renamed);
+    app.add_initializer(read_state_arg);
+    app.add_initializer(read_state_arg_multi);
+    app.add_initializer(read_state_same_arg);
+    app.add_initializer(read_resource_arg);
+    app.add_initializer(read_resource_arg_multi);
+    app.add_initializer(read_resource_same_arg);
+    app.add_initializer(non_async);
+    app.add_initializer(no_args);
+}

--- a/crates/macros/src/event.rs
+++ b/crates/macros/src/event.rs
@@ -9,9 +9,12 @@ struct EventArgs {
     value: Option<Ident>,
 }
 
+// #[derive(Event)]
+// #[event]
+// #[event(value = "String")]
 pub fn macro_impl(item: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(item);
-    let args = EventArgs::from_derive_input(&input).expect("Failed to parse #[event] arguments.");
+    let args = EventArgs::from_derive_input(&input).expect("Failed to parse arguments.");
 
     let struct_name = input.ident;
     let value_type = match args.value {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -2,6 +2,7 @@ mod event;
 mod listener;
 mod resource;
 mod state;
+mod system;
 
 use proc_macro::TokenStream;
 
@@ -23,4 +24,9 @@ pub fn resource(item: TokenStream) -> TokenStream {
 #[proc_macro_derive(State)]
 pub fn state(item: TokenStream) -> TokenStream {
     state::macro_impl(item)
+}
+
+#[proc_macro_attribute]
+pub fn system(args: TokenStream, item: TokenStream) -> TokenStream {
+    system::macro_impl(args, item)
 }

--- a/crates/macros/src/listener.rs
+++ b/crates/macros/src/listener.rs
@@ -10,10 +10,12 @@ struct ListenerArgs {
     once: bool,
 }
 
+// #[listener]
+// #[listener(once)]
 pub fn macro_impl(args: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as syn::ItemFn);
     let args = parse_macro_input!(args as AttributeArgs);
-    let args = ListenerArgs::from_list(&args).expect("Failed to parse #[listener] arguments.");
+    let args = ListenerArgs::from_list(&args).expect("Failed to parse arguments.");
 
     let func_name = func.sig.ident.to_string();
     let func_body = func.block;
@@ -25,7 +27,7 @@ pub fn macro_impl(args: TokenStream, item: TokenStream) -> TokenStream {
         .sig
         .inputs
         .first()
-        .expect("Macro #[listener] requires an event as the only argument.")
+        .expect("Requires an event as the only argument.")
     {
         FnArg::Receiver(_) => panic!("Cannot use &self as an event."),
         FnArg::Typed(arg) => match &*arg.ty {

--- a/crates/macros/src/resource.rs
+++ b/crates/macros/src/resource.rs
@@ -2,6 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Data, DeriveInput};
 
+// #[derive(Resource)]
 pub fn macro_impl(item: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(item);
     let struct_name = input.ident;

--- a/crates/macros/src/state.rs
+++ b/crates/macros/src/state.rs
@@ -14,8 +14,8 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
     match input.data {
         Data::Struct(data) => {
             match data.fields {
-                // Struct { field }
-                Fields::Named(_) => quote! {
+                // Struct, Struct { field }
+                Fields::Unit | Fields::Named(_) => quote! {
                     #shared_impl
 
                     impl AsRef<#struct_name> for #struct_name {
@@ -35,27 +35,28 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
                     let inner_type = &inner.ty;
 
                     let as_ref_extra = match inner_type {
-                        Type::Path(path) => {
-                            let is_pathbuf = path
-                                .path
-                                .get_ident()
-                                .map(|i| i == "PathBuf")
-                                .unwrap_or_default();
-
-                            // When the inner type is a `PathBuf`, we must also implement
-                            // `AsRef<Path>` for references to work correctly.
-                            if is_pathbuf {
-                                Some(quote! {
+                        // When the inner type is a `PathBuf`, we must also implement
+                        // `AsRef<Path>` for references to work correctly.
+                        Type::Path(path) => match path.path.get_ident() {
+                            Some(ident) => match ident.to_string().as_str() {
+                                "PathBuf" => Some(quote! {
                                     impl AsRef<std::path::Path> for #struct_name {
                                         fn as_ref(&self) -> &std::path::Path {
                                             &self.0
                                         }
                                     }
-                                })
-                            } else {
-                                None
-                            }
-                        }
+                                }),
+                                "RelativePathBuf" => Some(quote! {
+                                    impl AsRef<starship::RelativePath> for #struct_name {
+                                        fn as_ref(&self) -> &starship::RelativePath {
+                                            &self.0
+                                        }
+                                    }
+                                }),
+                                _ => None,
+                            },
+                            None => None,
+                        },
                         _ => None,
                     };
 
@@ -86,9 +87,6 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
                     }
                     .into()
                 }
-
-                // Struct
-                Fields::Unit => shared_impl.into(),
             }
         }
         Data::Enum(_) => shared_impl.into(),

--- a/crates/macros/src/state.rs
+++ b/crates/macros/src/state.rs
@@ -2,6 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
 
+// #[derive(State)]
 pub fn macro_impl(item: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(item);
     let struct_name = input.ident;

--- a/crates/macros/src/system.rs
+++ b/crates/macros/src/system.rs
@@ -27,6 +27,7 @@ impl<'a> SystemParam<'a> {
     }
 }
 
+// #[system]
 pub fn macro_impl(_args: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as syn::ItemFn);
     let func_name = func.sig.ident;

--- a/crates/macros/src/system.rs
+++ b/crates/macros/src/system.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
+use std::collections::HashMap;
 use syn::{parse_macro_input, FnArg, GenericArgument, Pat, PathArguments, Type};
 
 // var name -> inner type

--- a/crates/macros/src/system.rs
+++ b/crates/macros/src/system.rs
@@ -1,0 +1,153 @@
+use std::collections::HashMap;
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, FnArg, GenericArgument, Pat, PathArguments, Type};
+
+// var name -> inner type
+enum SystemParam<'a> {
+    ContextRef,
+    ResourceRef(&'a Type),
+    StateRef(&'a Type),
+}
+
+impl<'a> SystemParam<'a> {
+    pub fn is_mutable(&self) -> bool {
+        false
+    }
+}
+
+// if is_var_mut {
+//                 is_ctx_mut = true;
+
+//                 quote! {
+//                     let mut #var_name = #var_value;
+//                 }
+//             } else {
+//                 quote! {
+//                     let #var_name = #var_value;
+//                 }
+//             }
+
+pub fn macro_impl(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as syn::ItemFn);
+    let func_name = func.sig.ident;
+    let func_body = func.block;
+
+    // Convert inputs to system param enums
+    let mut mut_call_count = 0;
+    let params = func
+        .sig
+        .inputs
+        .iter()
+        .map(|i| {
+            let FnArg::Typed(input) = i else {
+                panic!("&self not permitted in system functions.");
+            };
+
+            let var_name = match input.pat.as_ref() {
+                Pat::Ident(ref pat) => &pat.ident,
+                _ => panic!("Unsupported parameter identifier pattern."),
+            };
+
+            let var_value = match input.ty.as_ref() {
+                Type::Path(ref path) => {
+                    // TypeWrapper<InnerType>
+                    let segment = path
+                        .path
+                        .segments
+                        .first()
+                        .unwrap_or_else(|| panic!("Required a parameter type for {}.", var_name));
+
+                    // TypeWrapper
+                    let type_wrapper = segment.ident.to_string();
+
+                    let param = if segment.arguments.is_empty() {
+                        match type_wrapper.as_ref() {
+                            "ContextRef" => SystemParam::ContextRef,
+                            wrapper => {
+                                panic!("Unknown parameter type {} for {}.", wrapper, var_name);
+                            }
+                        }
+                    } else {
+                        // <InnerType>
+                        let PathArguments::AngleBracketed(segment_args) = &segment.arguments else {
+                            panic!("Required a generic parameter type for {}.", type_wrapper);
+                        };
+
+                        // InnerType
+                        let GenericArgument::Type(inner_type) = segment_args.args.first().unwrap() else {
+                            panic!("Required a generic parameter type for {}.", type_wrapper);
+                        };
+
+                        match type_wrapper.as_ref() {
+                            "ResourceRef" => SystemParam::ResourceRef(inner_type),
+                            "StateRef" => SystemParam::StateRef(inner_type),
+                            wrapper => {
+                                panic!("Unknown parameter type {} for {}.", wrapper, var_name);
+                            }
+                        }
+                    };
+
+                    if param.is_mutable() {
+                        mut_call_count += 1;
+                    }
+
+                    param
+                }
+                _ => panic!("Unsupported parameter type for {}.", var_name),
+            };
+
+            (var_name, var_value)
+        })
+        .collect::<HashMap<_, _>>();
+
+    // When using mutable params, only 1 is allowed because of borrow rules
+    if mut_call_count > 1 {
+        panic!("Only 1 mutable parameter is allowed per system function.");
+    }
+
+    if params.len() > 1 {
+        // When using `ContextRef`, only 1 param is allowed as it takes precedence
+        if params
+            .iter()
+            .any(|(_, p)| matches!(p, SystemParam::ContextRef))
+        {
+            panic!("No additional parameters are allowed when using ContextRef.");
+        }
+    }
+
+    // Convert system params to context calls
+    let mut ctx_var_name = format_ident!("ctx");
+    let ctx_calls = params
+        .iter()
+        .map(|(k, p)| match p {
+            SystemParam::ContextRef => {
+                ctx_var_name = (*k).to_owned();
+                quote! {}
+            }
+            SystemParam::ResourceRef(inner) => quote! {
+                let #k = ctx.resource::<#inner>();
+            },
+            SystemParam::StateRef(inner) => quote! {
+                let #k = ctx.state::<#inner>();
+            },
+        })
+        .collect::<Vec<_>>();
+
+    let ctx_lock = if mut_call_count > 0 {
+        quote! { let mut #ctx_var_name = ctx.write().await; }
+    } else {
+        quote! { let #ctx_var_name = ctx.read().await; }
+    };
+
+    quote! {
+        async fn #func_name(ctx: starship::Context) -> starship::SystemResult {
+            #ctx_lock
+            #(#ctx_calls)*
+            #func_body
+            Ok(())
+        }
+    }
+    .into()
+}

--- a/crates/test-app/Cargo.toml
+++ b/crates/test-app/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 starship = { path = "../framework" }
-tokio = { version = "1.25.0", features = ["full", "tracing"] }
+tokio = { version = "1.26.0", features = ["full", "tracing"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.68.1"
+channel = "1.68.2"


### PR DESCRIPTION
This attribute will compile this:

```rust
#[system]
async fn test_system(arg1: ResourceRef<Resource1>, arg2: ResourceRef<Resource2>) {
    dbg!(arg1);
    dbg!(arg2);
}
```

To this:

```rust
async fn test_system(ctx: starship::Context) -> starship::SystemResult {
    let ctx = ctx.read().await;
    let arg1 = ctx.resource::<Resource1>();
    let arg2 = ctx.resource::<Resource2>();
    {
        dbg!(arg1);
        dbg!(arg2);
    }
    Ok(())
}
```

Which is pretty great because it gives us:

- Axum/Bevy style parameters, without the need for trait magic.
- Automatic read/write lock acquisitions.
- Return type/value can be omitted.