### PR TITLE
new: Add `AppState` layer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ async fn load_config(states: States, resources: Resources, emitters: Emitters) -
 
 #[tokio::main]
 async fn main() {
-	let mut app = App::default();
+	let mut app = App::new();
 	app.add_initializer(load_config);
 	app.run()?;
 }

--- a/crates/framework/src/app.rs
+++ b/crates/framework/src/app.rs
@@ -1,3 +1,4 @@
+use crate::app_state::*;
 use crate::events::{EmitterInstance, EmitterManager, Emitters};
 use crate::resources::{ResourceInstance, ResourceManager, Resources};
 use crate::states::{StateInstance, StateManager, States};
@@ -20,8 +21,6 @@ pub enum Phase {
 
 #[derive(Debug, Default)]
 pub struct App {
-    pub current_phase: Option<Phase>,
-
     // Data
     emitters: EmitterManager,
     resources: ResourceManager,
@@ -35,6 +34,15 @@ pub struct App {
 }
 
 impl App {
+    pub fn new() -> App {
+        let mut app = App::default();
+        app.add_initializer(start_initialize_phase);
+        app.add_analyzer(start_analyze_phase);
+        app.add_executor(start_execute_phase);
+        app.add_initializer(start_finalize_phase);
+        app
+    }
+
     /// Add a system function that runs during the initialization phase.
     pub fn add_initializer<S: SystemFunc + 'static>(&mut self, system: S) -> &mut Self {
         self.add_system(Phase::Initialize, CallbackSystem::new(system))
@@ -159,8 +167,6 @@ impl App {
     ) -> anyhow::Result<()> {
         let systems = mem::take(&mut self.initializers);
 
-        self.current_phase = Some(Phase::Initialize);
-
         self.run_systems_in_serial(systems, states, resources, emitters)
             .await?;
 
@@ -174,8 +180,6 @@ impl App {
         emitters: Emitters,
     ) -> anyhow::Result<()> {
         let systems = mem::take(&mut self.analyzers);
-
-        self.current_phase = Some(Phase::Analyze);
 
         self.run_systems_in_parallel(systems, states, resources, emitters)
             .await?;
@@ -191,8 +195,6 @@ impl App {
     ) -> anyhow::Result<()> {
         let systems = mem::take(&mut self.executors);
 
-        self.current_phase = Some(Phase::Execute);
-
         self.run_systems_in_parallel(systems, states, resources, emitters)
             .await?;
 
@@ -206,8 +208,6 @@ impl App {
         emitters: Emitters,
     ) -> anyhow::Result<()> {
         let systems = mem::take(&mut self.finalizers);
-
-        self.current_phase = Some(Phase::Finalize);
 
         self.run_systems_in_parallel(systems, states, resources, emitters)
             .await?;

--- a/crates/framework/src/app.rs
+++ b/crates/framework/src/app.rs
@@ -19,7 +19,7 @@ pub enum Phase {
     Finalize,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct App {
     // Data
     emitters: EmitterManager,
@@ -35,11 +35,19 @@ pub struct App {
 
 impl App {
     pub fn new() -> App {
-        let mut app = App::default();
+        let mut app = App {
+            analyzers: vec![],
+            emitters: EmitterManager::default(),
+            executors: vec![],
+            finalizers: vec![],
+            initializers: vec![],
+            resources: ResourceManager::default(),
+            states: StateManager::default(),
+        };
         app.add_initializer(start_initialize_phase);
         app.add_analyzer(start_analyze_phase);
         app.add_executor(start_execute_phase);
-        app.add_initializer(start_finalize_phase);
+        app.add_finalizer(start_finalize_phase);
         app
     }
 

--- a/crates/framework/src/app_state.rs
+++ b/crates/framework/src/app_state.rs
@@ -9,27 +9,27 @@ mod starship {
 
 #[derive(Debug, State)]
 pub struct AppState {
-    pub current_phase: Phase,
+    pub phase: Phase,
 }
 
 #[system]
 pub async fn start_initialize_phase(states: StatesMut) {
     states.set(AppState {
-        current_phase: Phase::Initialize,
+        phase: Phase::Initialize,
     });
 }
 
 #[system]
 pub async fn start_analyze_phase(app_state: StateMut<AppState>) {
-    app_state.current_phase = Phase::Analyze;
+    app_state.phase = Phase::Analyze;
 }
 
 #[system]
 pub async fn start_execute_phase(app_state: StateMut<AppState>) {
-    app_state.current_phase = Phase::Analyze;
+    app_state.phase = Phase::Execute;
 }
 
 #[system]
 pub async fn start_finalize_phase(app_state: StateMut<AppState>) {
-    app_state.current_phase = Phase::Finalize;
+    app_state.phase = Phase::Finalize;
 }

--- a/crates/framework/src/app_state.rs
+++ b/crates/framework/src/app_state.rs
@@ -1,0 +1,35 @@
+use crate::app::Phase;
+use starship_macros::{system, State};
+
+// This is a hack for starship macros to work from within
+// the starship crate itself!
+mod starship {
+    pub use crate::*;
+}
+
+#[derive(Debug, State)]
+pub struct AppState {
+    pub current_phase: Phase,
+}
+
+#[system]
+pub async fn start_initialize_phase(states: StatesMut) {
+    states.set(AppState {
+        current_phase: Phase::Initialize,
+    });
+}
+
+#[system]
+pub async fn start_analyze_phase(app_state: StateMut<AppState>) {
+    app_state.current_phase = Phase::Analyze;
+}
+
+#[system]
+pub async fn start_execute_phase(app_state: StateMut<AppState>) {
+    app_state.current_phase = Phase::Analyze;
+}
+
+#[system]
+pub async fn start_finalize_phase(app_state: StateMut<AppState>) {
+    app_state.current_phase = Phase::Finalize;
+}

--- a/crates/framework/src/lib.rs
+++ b/crates/framework/src/lib.rs
@@ -1,4 +1,5 @@
 mod app;
+mod app_state;
 mod events;
 mod instance;
 mod resources;
@@ -6,6 +7,7 @@ mod states;
 mod system;
 
 pub use app::*;
+pub use app_state::AppState;
 pub use events::*;
 pub use resources::*;
 pub use starship_macros::*;

--- a/crates/framework/tests/system_macros_test.rs
+++ b/crates/framework/tests/system_macros_test.rs
@@ -204,7 +204,7 @@ fn non_async() {
 
 #[tokio::test]
 async fn test_app() {
-    let mut app = App::default();
+    let mut app = App::new();
     app.add_initializer(read_states);
     app.add_initializer(read_states_renamed);
     app.add_initializer(read_state_arg);

--- a/crates/macros/src/system.rs
+++ b/crates/macros/src/system.rs
@@ -181,6 +181,7 @@ pub fn macro_impl(_args: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as syn::ItemFn);
     let func_name = func.sig.ident;
     let func_body = func.block;
+    let func_vis = func.vis;
 
     // Types of instances
     let mut states = InstanceTracker::new(InstanceType::State);
@@ -273,7 +274,7 @@ pub fn macro_impl(_args: TokenStream, item: TokenStream) -> TokenStream {
     let emitter_quotes = emitters.generate_quotes();
 
     quote! {
-        async fn #func_name(
+        #func_vis async fn #func_name(
             states: starship::States,
             resources: starship::Resources,
             emitters: starship::Emitters

--- a/crates/test-app/src/main.rs
+++ b/crates/test-app/src/main.rs
@@ -41,7 +41,7 @@ async fn fin(states: States, _resources: Resources, _emitters: Emitters) -> Resu
 
 #[tokio::main]
 async fn main() {
-    let mut app = App::default();
+    let mut app = App::new();
     app.add_finalizer(fin);
     app.add_analyzer(anal1);
     app.add_initializer(init1);


### PR DESCRIPTION
This provides app state that starship owns, but consumers can hook into. Right now we're only tracking the phase.